### PR TITLE
Add collapsible sidebar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,10 +4,11 @@ import { Metadata } from "next"
 import { siteConfig } from "@/config/site"
 import { fontSans } from "@/lib/fonts"
 import { cn } from "@/lib/utils"
-import { SidebarContent } from "@/components/sidebar"
+import { AppSidebar } from "@/components/app-sidebar"
 import { SiteHeader } from "@/components/site-header"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { ThemeProvider } from "@/components/theme-provider"
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar"
 
 export const metadata: Metadata = {
   title: {
@@ -42,14 +43,18 @@ export default function RootLayout({ children }: RootLayoutProps) {
           )}
         >
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-            <div className="relative flex min-h-screen flex-col">
-              <SiteHeader />
-              <div className="flex-1 md:flex">
-                <aside className="hidden w-64 shrink-0 border-r bg-muted/50 md:block">
-                  <SidebarContent />
-                </aside>
-                <main className="flex-1">{children}</main>
-              </div>
+            <div className="[--header-height:calc(theme(spacing.14))]">
+              <SidebarProvider className="flex flex-col min-h-screen">
+                <SiteHeader />
+                <div className="flex flex-1">
+                  <AppSidebar />
+                  <SidebarInset>
+                    <main className="flex flex-1 flex-col gap-4 p-4">
+                      {children}
+                    </main>
+                  </SidebarInset>
+                </div>
+              </SidebarProvider>
             </div>
             <TailwindIndicator />
           </ThemeProvider>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import * as React from "react"
+import {
+  BookOpen,
+  Bot,
+  Frame,
+  LifeBuoy,
+  Map,
+  PieChart,
+  Send,
+  Settings2,
+  TerminalSquare,
+} from "lucide-react"
+
+import { NavMain } from "@/components/nav-main"
+import { NavProjects } from "@/components/nav-projects"
+import { NavSecondary } from "@/components/nav-secondary"
+import { NavUser } from "@/components/nav-user"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+} from "@/components/ui/sidebar"
+
+const data = {
+  user: {
+    name: "shadcn",
+    email: "m@example.com",
+    avatar: "/avatars/shadcn.jpg",
+  },
+  navMain: [
+    {
+      title: "Playground",
+      url: "#",
+      icon: TerminalSquare,
+      isActive: true,
+      items: [
+        { title: "History", url: "#" },
+        { title: "Starred", url: "#" },
+        { title: "Settings", url: "#" },
+      ],
+    },
+    {
+      title: "Models",
+      url: "#",
+      icon: Bot,
+      items: [
+        { title: "Genesis", url: "#" },
+        { title: "Explorer", url: "#" },
+        { title: "Quantum", url: "#" },
+      ],
+    },
+    {
+      title: "Documentation",
+      url: "#",
+      icon: BookOpen,
+      items: [
+        { title: "Introduction", url: "#" },
+        { title: "Get Started", url: "#" },
+        { title: "Tutorials", url: "#" },
+        { title: "Changelog", url: "#" },
+      ],
+    },
+    {
+      title: "Settings",
+      url: "#",
+      icon: Settings2,
+      items: [
+        { title: "General", url: "#" },
+        { title: "Team", url: "#" },
+        { title: "Billing", url: "#" },
+        { title: "Limits", url: "#" },
+      ],
+    },
+  ],
+  navSecondary: [
+    { title: "Support", url: "#", icon: LifeBuoy },
+    { title: "Feedback", url: "#", icon: Send },
+  ],
+  projects: [
+    { name: "Design Engineering", url: "#", icon: Frame },
+    { name: "Sales & Marketing", url: "#", icon: PieChart },
+    { name: "Travel", url: "#", icon: Map },
+  ],
+}
+
+export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
+  return (
+    <Sidebar
+      className="top-[--header-height] h-[calc(100svh-var(--header-height))]!"
+      {...props}
+    >
+      <SidebarHeader>
+        <NavProjects projects={data.projects} />
+      </SidebarHeader>
+      <SidebarContent>
+        <NavMain items={data.navMain} />
+        <NavSecondary items={data.navSecondary} className="mt-auto" />
+      </SidebarContent>
+      <SidebarFooter>
+        <NavUser user={data.user} />
+      </SidebarFooter>
+    </Sidebar>
+  )
+}

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { ChevronRight, type LucideIcon } from "lucide-react"
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+} from "@/components/ui/sidebar"
+
+export function NavMain({
+  items,
+}: {
+  items: {
+    title: string
+    url: string
+    icon: LucideIcon
+    isActive?: boolean
+    items?: { title: string; url: string }[]
+  }[]
+}) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Platform</SidebarGroupLabel>
+      <SidebarMenu>
+        {items.map((item) => (
+          <Collapsible key={item.title} asChild defaultOpen={item.isActive}>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild title={item.title}>
+                <a href={item.url} className="flex items-center gap-2">
+                  <item.icon className="size-4" />
+                  <span>{item.title}</span>
+                </a>
+              </SidebarMenuButton>
+              {item.items?.length ? (
+                <>
+                  <CollapsibleTrigger asChild>
+                    <SidebarMenuAction className="data-[state=open]:rotate-90">
+                      <ChevronRight className="size-4" />
+                      <span className="sr-only">Toggle</span>
+                    </SidebarMenuAction>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <SidebarMenuSub>
+                      {item.items.map((sub) => (
+                        <SidebarMenuSubItem key={sub.title}>
+                          <SidebarMenuSubButton asChild>
+                            <a href={sub.url}>{sub.title}</a>
+                          </SidebarMenuSubButton>
+                        </SidebarMenuSubItem>
+                      ))}
+                    </SidebarMenuSub>
+                  </CollapsibleContent>
+                </>
+              ) : null}
+            </SidebarMenuItem>
+          </Collapsible>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/components/nav-projects.tsx
+++ b/components/nav-projects.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { type LucideIcon } from "lucide-react"
+
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+
+export function NavProjects({
+  projects,
+}: {
+  projects: { name: string; url: string; icon: LucideIcon }[]
+}) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Projects</SidebarGroupLabel>
+      <SidebarMenu>
+        {projects.map((project) => (
+          <SidebarMenuItem key={project.name}>
+            <SidebarMenuButton asChild>
+              <a href={project.url} className="flex items-center gap-2">
+                <project.icon className="size-4" />
+                <span>{project.name}</span>
+              </a>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/components/nav-secondary.tsx
+++ b/components/nav-secondary.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { type LucideIcon } from "lucide-react"
+
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+
+export function NavSecondary({
+  items,
+  className,
+}: {
+  items: { title: string; url: string; icon: LucideIcon }[]
+  className?: string
+}) {
+  return (
+    <SidebarGroup className={className}>
+      <SidebarGroupLabel>Help</SidebarGroupLabel>
+      <SidebarMenu>
+        {items.map((item) => (
+          <SidebarMenuItem key={item.title}>
+            <SidebarMenuButton asChild>
+              <a href={item.url} className="flex items-center gap-2">
+                <item.icon className="size-4" />
+                <span>{item.title}</span>
+              </a>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { User } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  SidebarGroup,
+  SidebarMenuButton,
+} from "@/components/ui/sidebar"
+
+export function NavUser({
+  user,
+}: {
+  user: { name: string; email: string; avatar: string }
+}) {
+  return (
+    <SidebarGroup>
+      <SidebarMenuButton asChild>
+        <a href="#" className="flex items-center gap-2">
+          <User className="size-6" />
+          <div className="grid text-left">
+            <span className="text-sm font-medium leading-tight">{user.name}</span>
+            <span className="text-xs text-muted-foreground">{user.email}</span>
+          </div>
+        </a>
+      </SidebarMenuButton>
+      <Button variant="outline" className="w-full">
+        Sign out
+      </Button>
+    </SidebarGroup>
+  )
+}

--- a/components/search-form.tsx
+++ b/components/search-form.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { Search } from "lucide-react"
+import { cn } from "@/lib/utils"
+import * as React from "react"
+
+export function SearchForm({ className }: React.HTMLAttributes<HTMLFormElement>) {
+  return (
+    <form className={cn("relative flex items-center", className)}>
+      <Search className="absolute left-2 size-4 text-muted-foreground" />
+      <input
+        type="search"
+        placeholder="Search"
+        className="h-8 w-full rounded-md border bg-background py-1 pl-7 pr-2 text-sm shadow-sm"
+      />
+    </form>
+  )
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,53 +1,42 @@
-import Link from "next/link"
+"use client"
 
-import { siteConfig } from "@/config/site"
-import { buttonVariants } from "@/components/ui/button"
-import { Icons } from "@/components/icons"
-import { MainNav } from "@/components/main-nav"
-import { SidebarToggle } from "@/components/sidebar"
-import { ThemeToggle } from "@/components/theme-toggle"
+import { SidebarIcon } from "lucide-react"
+
+import { SearchForm } from "@/components/search-form"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { useSidebar } from "@/components/ui/sidebar"
 
 export function SiteHeader() {
+  const { toggleSidebar } = useSidebar()
+
   return (
-    <header className="bg-background sticky top-0 z-40 w-full border-b">
-      <div className="container flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0">
-        <SidebarToggle />
-        <MainNav items={siteConfig.mainNav} />
-        <div className="flex flex-1 items-center justify-end space-x-4">
-          <nav className="flex items-center space-x-1">
-            <Link
-              href={siteConfig.links.github}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <div
-                className={buttonVariants({
-                  size: "icon",
-                  variant: "ghost",
-                })}
-              >
-                <Icons.gitHub className="h-5 w-5" />
-                <span className="sr-only">GitHub</span>
-              </div>
-            </Link>
-            <Link
-              href={siteConfig.links.twitter}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <div
-                className={buttonVariants({
-                  size: "icon",
-                  variant: "ghost",
-                })}
-              >
-                <Icons.twitter className="h-5 w-5 fill-current" />
-                <span className="sr-only">Twitter</span>
-              </div>
-            </Link>
-            <ThemeToggle />
-          </nav>
-        </div>
+    <header className="bg-background sticky top-0 z-50 flex w-full items-center border-b">
+      <div className="flex h-[--header-height] w-full items-center gap-2 px-4">
+        <Button className="h-8 w-8" variant="ghost" size="icon" onClick={toggleSidebar}>
+          <SidebarIcon />
+        </Button>
+        <Separator orientation="vertical" className="mr-2 h-4" />
+        <Breadcrumb className="hidden sm:block">
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="#">Building Your Application</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>Data Fetching</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+        <SearchForm className="w-full sm:ml-auto sm:w-auto" />
       </div>
     </header>
   )

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export function Breadcrumb({ className, ...props }: React.HTMLAttributes<HTMLElement>) {
+  return <nav className={cn("flex", className)} {...props} />
+}
+
+export function BreadcrumbList({ className, ...props }: React.HTMLAttributes<HTMLOListElement>) {
+  return <ol className={cn("flex items-center gap-1", className)} {...props} />
+}
+
+export function BreadcrumbItem({ className, ...props }: React.HTMLAttributes<HTMLLIElement>) {
+  return <li className={cn("text-sm", className)} {...props} />
+}
+
+export function BreadcrumbLink({ className, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return <a className={cn("font-medium", className)} {...props} />
+}
+
+export function BreadcrumbPage({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
+  return <span className={cn("font-semibold", className)} {...props} />
+}
+
+export function BreadcrumbSeparator({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
+  return <span role="presentation" className={cn("mx-1 text-muted-foreground", className)} {...props} />
+}

--- a/components/ui/collapsible.tsx
+++ b/components/ui/collapsible.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import * as React from "react"
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+import { cn } from "@/lib/utils"
+
+const Collapsible = CollapsiblePrimitive.Root
+const CollapsibleTrigger = CollapsiblePrimitive.Trigger
+const CollapsibleContent = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <CollapsiblePrimitive.Content
+    ref={ref}
+    className={cn("overflow-hidden", className)}
+    {...props}
+  />
+))
+CollapsibleContent.displayName = CollapsiblePrimitive.Content.displayName
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical"
+}
+
+export function Separator({ orientation = "horizontal", className, ...props }: SeparatorProps) {
+  return (
+    <div
+      role="separator"
+      className={cn(
+        "bg-border shrink-0",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -1,0 +1,176 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { useMediaQuery } from "@/lib/hooks/use-media-query"
+import { Sheet, SheetContent } from "@/components/ui/sheet"
+import { Slot } from "@radix-ui/react-slot"
+
+interface SidebarContextValue {
+  isCollapsed: boolean
+  setCollapsed: (value: boolean) => void
+  isOpen: boolean
+  setOpen: (value: boolean) => void
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextValue | undefined>(undefined)
+
+export function SidebarProvider({
+  children,
+  className,
+}: React.PropsWithChildren<{ className?: string }>) {
+  const [isCollapsed, setCollapsed] = React.useState(false)
+  const [isOpen, setOpen] = React.useState(false)
+  const isDesktop = useMediaQuery("(min-width: 768px)")
+
+  const toggleSidebar = React.useCallback(() => {
+    if (isDesktop) {
+      setCollapsed((prev) => !prev)
+    } else {
+      setOpen((prev) => !prev)
+    }
+  }, [isDesktop])
+
+  return (
+    <SidebarContext.Provider
+      value={{ isCollapsed, setCollapsed, isOpen, setOpen, toggleSidebar }}
+    >
+      <div className={cn(className)}>{children}</div>
+    </SidebarContext.Provider>
+  )
+}
+
+export function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) throw new Error("useSidebar must be used within SidebarProvider")
+  return context
+}
+
+export const SidebarTrigger = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+  ({ className, ...props }, ref) => {
+    const { toggleSidebar } = useSidebar()
+    return (
+      <button
+        ref={ref}
+        onClick={toggleSidebar}
+        className={cn(
+          "inline-flex items-center justify-center rounded-md p-2 hover:bg-sidebar-accent",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+SidebarTrigger.displayName = "SidebarTrigger"
+
+export function Sidebar({ className, children }: React.HTMLAttributes<HTMLElement>) {
+  const { isCollapsed, isOpen, setOpen } = useSidebar()
+  return (
+    <>
+      <Sheet open={isOpen} onOpenChange={setOpen}>
+        <SheetContent side="left" className="sm:max-w-xs md:hidden">
+          {children}
+        </SheetContent>
+      </Sheet>
+      <aside
+        data-collapsed={isCollapsed}
+        className={cn(
+          "group/sidebar hidden border-r bg-sidebar text-sidebar-foreground transition-all md:block",
+          isCollapsed ? "w-14" : "w-64",
+          className
+        )}
+      >
+        {children}
+      </aside>
+    </>
+  )
+}
+
+export function SidebarInset({ className, children }: React.HTMLAttributes<HTMLDivElement>) {
+  const { isCollapsed } = useSidebar()
+  return (
+    <div
+      className={cn(
+        "flex flex-col transition-all",
+        isCollapsed ? "md:ml-14" : "md:ml-64",
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+export function SidebarHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("px-4 py-2", className)} {...props} />
+}
+
+export function SidebarFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("mt-auto px-4 py-2", className)} {...props} />
+}
+
+export function SidebarContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col gap-2 px-2 py-4", className)} {...props} />
+}
+
+export function SidebarGroup({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("grid gap-2", className)} {...props} />
+}
+
+export function SidebarGroupLabel({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h4 className={cn("px-3 text-xs font-semibold text-muted-foreground", className)} {...props} />
+}
+
+export function SidebarMenu({ className, ...props }: React.HTMLAttributes<HTMLUListElement>) {
+  return <ul className={cn("grid gap-1", className)} {...props} />
+}
+
+export function SidebarMenuItem({ className, ...props }: React.HTMLAttributes<HTMLLIElement>) {
+  return <li className={cn(className)} {...props} />
+}
+
+export function SidebarMenuButton({ asChild, className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'button'
+  return (
+    <Comp
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-3 py-2 hover:bg-sidebar-accent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function SidebarMenuAction({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={cn("ml-auto p-1 text-muted-foreground hover:text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export function SidebarMenuSub({ className, ...props }: React.HTMLAttributes<HTMLUListElement>) {
+  return <ul className={cn("ml-6 grid gap-1", className)} {...props} />
+}
+
+export function SidebarMenuSubItem({ className, ...props }: React.HTMLAttributes<HTMLLIElement>) {
+  return <li className={cn(className)} {...props} />
+}
+
+export function SidebarMenuSubButton({ asChild, className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'button'
+  return (
+    <Comp
+      className={cn(
+        "flex w-full items-center rounded-md px-3 py-1.5 hover:bg-sidebar-accent",
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/lib/hooks/use-media-query.ts
+++ b/lib/hooks/use-media-query.ts
@@ -1,0 +1,22 @@
+"use client"
+
+import * as React from "react"
+
+export function useMediaQuery(query: string) {
+  const getMatches = () => (typeof window !== "undefined" ? window.matchMedia(query).matches : false)
+
+  const [matches, setMatches] = React.useState(getMatches)
+
+  React.useEffect(() => {
+    const matchMedia = window.matchMedia(query)
+
+    const handleChange = () => setMatches(matchMedia.matches)
+
+    handleChange()
+
+    matchMedia.addEventListener("change", handleChange)
+    return () => matchMedia.removeEventListener("change", handleChange)
+  }, [query])
+
+  return matches
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "next-template",
       "version": "0.0.2",
       "dependencies": {
+        "@radix-ui/react-collapsible": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-slot": "^1.0.2",
@@ -787,6 +788,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.11.tgz",
+      "integrity": "sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,mdx}\" --cache"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-slot": "^1.0.2",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -34,6 +34,16 @@
     --ring: 215 20.2% 65.1%;
 
     --radius: 0.5rem;
+
+    /* Sidebar colors */
+    --sidebar: oklch(0.985 0 0);
+    --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar-primary: oklch(0.205 0 0);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.97 0 0);
+    --sidebar-accent-foreground: oklch(0.205 0 0);
+    --sidebar-border: oklch(0.922 0 0);
+    --sidebar-ring: oklch(0.708 0 0);
   }
 
   .dark {
@@ -67,6 +77,16 @@
     --ring: 216 34% 17%;
 
     --radius: 0.5rem;
+
+    /* Sidebar colors */
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.439 0 0);
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,6 +47,16 @@ module.exports = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        sidebar: {
+          DEFAULT: "oklch(var(--sidebar))",
+          foreground: "oklch(var(--sidebar-foreground))",
+          primary: "oklch(var(--sidebar-primary))",
+          "primary-foreground": "oklch(var(--sidebar-primary-foreground))",
+          accent: "oklch(var(--sidebar-accent))",
+          "accent-foreground": "oklch(var(--sidebar-accent-foreground))",
+          border: "oklch(var(--sidebar-border))",
+          ring: "oklch(var(--sidebar-ring))",
+        },
       },
       borderRadius: {
         lg: `var(--radius)`,


### PR DESCRIPTION
## Summary
- create sidebar provider with toggleSidebar
- implement sidebar components and navigation menus
- add search form and breadcrumbs
- update layout and header to toggle sidebar
- install @radix-ui/react-collapsible dependency

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68472d1cf8e0832795be1b45a04256a2